### PR TITLE
fix(IOS_CALCULATOR): use relative path to load index.js

### DIFF
--- a/IOS_CALCULATOR/index.html
+++ b/IOS_CALCULATOR/index.html
@@ -32,6 +32,6 @@
             </div>
         </div>
 
-        <script src="/IOS_CALCULATOR/index.js"></script>
+        <script src="./index.js"></script>
     </body>
 </html>


### PR DESCRIPTION
User may use various paths to open this website.
Load index.js use relative path can avoid issues caused by different paths. 
For example urls:
    https://berniehuang2008.github.io/Learning_Web_Development/IOS_CALCULATOR
    http://localhost:8000
    http://localhost:8000/IOS_CALCULATOR